### PR TITLE
Fix missing type bug for FileProtocol

### DIFF
--- a/modules/cbmailservices/models/protocols/FileProtocol.cfc
+++ b/modules/cbmailservices/models/protocols/FileProtocol.cfc
@@ -75,7 +75,7 @@ Description :
 		
 		<cfsavecontent variable="thisMail">
 		<cfoutput>
-			Sent at: #now()#<br/>
+			Sent at: #dateTimeFormat( now(), "full" )#<br/>
 			<hr/>
 			Mail Attributes
 			<hr/>

--- a/modules/cbmailservices/models/protocols/FileProtocol.cfc
+++ b/modules/cbmailservices/models/protocols/FileProtocol.cfc
@@ -91,7 +91,8 @@ Description :
 			<hr/>
 			Mail Body
 			<hr/>
-			<cfif arguments.mail.getMemento().type eq "text">
+			<cfif structKeyExists( arguments.mail.getMemento(), "type" ) AND
+				  arguments.mail.getMemento().type eq "text">
 		    <pre>#htmlcodeformat( arguments.mail.getBody() )#</pre>
 		    <cfelse>
 		    #arguments.mail.getBody()#

--- a/tests/specs/protocols/FileProtocolTest.cfc
+++ b/tests/specs/protocols/FileProtocolTest.cfc
@@ -75,4 +75,27 @@
 
 	</cffunction>
 
+	<cffunction name="testDoesNotFailIfNoTypeWasProvided" access="public" output="false" returntype="void">
+		<cfscript>
+			payload = getMockBox().createMock(className="cbmailservices.models.Mail").init().config(from="info@coldbox.org",to="automation@coldbox.org",subject="Mail With Params - Hello Luis");
+			payload.setBody("Hello This is my great unit test");
+			payload.addMailParam(name="Disposition-Notification-To",value="info@coldbox.org");
+			payload.addMailParam(name="Importance",value="High");
+			rtn = protocol.send(payload);
+			debug(rtn);
+
+			// Check if files exist
+
+		</cfscript>
+
+		<cfdirectory action="list" directory="#expandPath('/tests/specs/protocols/tmp')#" filter="*.html" listinfo="name" name="qTesting" >
+
+		<cfset debug(qTesting)>
+		<cfset AssertTrue( qTesting.recordcount )>
+
+		<cfloop query="qTesting">
+			<cfset fileDelete( expandPath('/tests/specs/protocols/tmp/#qTesting.name#') )>
+		</cfloop>
+	</cffunction>
+
 </cfcomponent>


### PR DESCRIPTION
If the `type` was missing, the email would not log.  This pull requests checks for the existance of a type before trying to access it directly to fix that error.  A test was also added to show this bug.

This pull request also formats the date time string in the logged email for better readability.
`Saturday, September 3, 2016 9:49:37 AM MDT` instead of `{ts '2016-09-03 09:49:37'}`